### PR TITLE
didChangeItemsAtRows added

### DIFF
--- a/Pod/Classes/CZPickerView.h
+++ b/Pod/Classes/CZPickerView.h
@@ -51,6 +51,14 @@
 - (void)czpickerView:(CZPickerView *)pickerView
           didConfirmWithItemsAtRows:(NSArray *)rows;
 
+/*
+ delegate method for selecting/unselecting multiple items,
+ implement this method if allowMultipleSelection is YES,
+ rows is an array of NSNumbers
+ */
+- (void)czpickerView:(CZPickerView *)pickerView
+didChangeItemsAtRows:(NSArray *)rows;
+
 /** delegate method for canceling */
 - (void)czpickerViewDidClickCancelButton:(CZPickerView *)pickerView;
 

--- a/Pod/Classes/CZPickerView.m
+++ b/Pod/Classes/CZPickerView.m
@@ -378,6 +378,7 @@ typedef void (^CZDismissCompletionCallback)(void);
             [self.selectedIndexPaths addObject:indexPath];
             cell.accessoryType = UITableViewCellAccessoryCheckmark;
         }
+        [self.delegate czpickerView:self didChangeItemsAtRows:[self selectedRows]];
         
     } else { //single selection mode
         


### PR DESCRIPTION
usage sample for enum

func czpickerView(_ pickerView: CZPickerView!, didChangeItemsAtRows rows: [Any]!) {
        
        if (pickerView == pickerPref) {
            
            var values = [UserPref]()
            
            for row in rows {
                if let row = row as? Int {
                    print(pickerPrefArray[row])
                    values.append(pickerPrefArray[row])
                }
            }
            
            if (values.count>1) {
            
                if (values.contains(.some)) {
                    pickerView.unselectAll()
                    print("You cannot select some with other options")
                }
                
            }
            
        }
    }